### PR TITLE
onDelete cascade constraint

### DIFF
--- a/database/migrations/2023_01_14_210732_change_foreign_key_cascade.php
+++ b/database/migrations/2023_01_14_210732_change_foreign_key_cascade.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+      Schema::table('users', function($table) {
+				$table->foreign('account_id')->change()->onDelete('cascade');
+			});
+      Schema::table('excemptions', function($table) {
+				$table->foreign('user_id')->change()->onDelete('cascade');
+			});
+      Schema::table('positions', function($table) {
+				$table->foreign('user_id')->change()->onDelete('cascade');
+			});
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};


### PR DESCRIPTION
This adds an `onDelete('cascade')` to foreign keys to fix deletion of accounts.