### PR TITLE
Take exemptions on cycle start into account

### DIFF
--- a/app/Models/Parameter.php
+++ b/app/Models/Parameter.php
@@ -41,6 +41,6 @@ class Parameter extends Model
 	public static function startAccounting()
 	{
 		$start = new DateTime(self::key('start_accounting'));
-		return date_date_set($start, date("Y"), $start->format('m'), $start->format('d'));
+		return date_date_set($start, date('Y'), $start->format('m'), $start->format('d'));
 	}
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -139,7 +139,7 @@ class User extends Authenticatable
 		$cycle = Parameter::startAccounting();
 		$start = $cycle < now() ? $cycle : $cycle->modify('-1 year');
 		$hours = 0;
-		foreach ($this->positions->where('completed_at', '>', $start->format('Y-m-d')) as $p) {
+		foreach ($this->positions->where('completed_at', '>=', $start->format('Y-m-d')) as $p) {
 			$hours += $p->hours;
 		}
 		return $hours;
@@ -153,7 +153,7 @@ class User extends Authenticatable
 		$cycle = Parameter::startAccounting();
 		$start = $cycle < now() ? $cycle : $cycle->modify('-1 year');
 		$days = 0;
-		foreach ($this->excemptions->where('start', '>', $start->format('Y-m-d')) as $e) {
+		foreach ($this->excemptions->where('start', '>=', $start->format('Y-m-d')) as $e) {
 			$begin = new DateTime($e->start);
 			$end = new DateTime($e->end);
 			$diff = $begin->diff($end)->days;


### PR DESCRIPTION
This change fixes the cycle hours calculation, when an exemption started on the same day as the cycle.