### PR TITLE
Rule to deny login for archived users

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -55,7 +55,7 @@ class LoginRequest extends FormRequest
 			},
 			$this->boolean('remember')
 		)) {
-			// RateLimiter::hit($this->throttleKey());
+			RateLimiter::hit($this->throttleKey());
 
 			throw ValidationException::withMessages([
 				'email' => trans('auth.failed'),

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Auth;
 
+use App\Models\User;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
@@ -45,8 +46,16 @@ class LoginRequest extends FormRequest
 	{
 		$this->ensureIsNotRateLimited();
 
-		if (! Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
-			RateLimiter::hit($this->throttleKey());
+		if (! Auth::attemptWhen(
+			$this->only('email', 'password'),
+			function (User $user) {
+				// Only allow login for users with an active account.
+				// Users of archived accounts cannot log in anymore.
+				return $user->account->active;
+			},
+			$this->boolean('remember')
+		)) {
+			// RateLimiter::hit($this->throttleKey());
 
 			throw ValidationException::withMessages([
 				'email' => trans('auth.failed'),


### PR DESCRIPTION
This change fixes a bug where users of archived accounts could still login.

Closes #26 